### PR TITLE
remove Patagames.Pdf

### DIFF
--- a/SpaceFlight/SpaceFlight.csproj
+++ b/SpaceFlight/SpaceFlight.csproj
@@ -36,8 +36,6 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Patagames.Pdf, Version=5.22.16.461, Culture=neutral, PublicKeyToken=60fd6cf9b15941cf" />
-    <Reference Include="Patagames.Pdf.WinForms, Version=4.6.7.461, Culture=neutral, PublicKeyToken=60fd6cf9b15941cf, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Patagames.Pdf is not needed for anything and Visual Studio shows a warning because the package is missing. If you plan to implement it later close the pull request.